### PR TITLE
Remove erroneous --cpu-unbound definition from main.cc

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -138,7 +138,6 @@ bool parse_global_option(std::vector<std::string>& args) {
     { 'N', "version", NO_PARAMETER },
     { 'S', "suppress-environment-warnings", NO_PARAMETER },
     { 'T', "dump-at", HAS_PARAMETER },
-    { 'U', "cpu-unbound", NO_PARAMETER },
   };
 
   ParsedOption opt;


### PR DESCRIPTION
The (undocumented and unused) --cpu-unbound definition in main.cc hides the (correct and intended) definition in RecordCommand.cc, with the result that this option doesn't work.  Removing the definition from main.cc fixes that issue.